### PR TITLE
Added `SCRATCH_DIR` and `OUT_DIR` global variables in the Python traces

### DIFF
--- a/examples/example2/config.yml
+++ b/examples/example2/config.yml
@@ -31,9 +31,6 @@ locations:
   l2:
     hostname: 127.0.0.1
     port: 8082
-  l3:
-    hostname: 127.0.0.1
-    port: 8083
 
 dependencies:
   d1:

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -44,15 +44,11 @@ from typing import Any, MutableMapping, MutableSequence
 global_vars = """
 
 BUF_SIZE = 8192
-OUT_DIR = str(Path("{{location_out_dir}}").expanduser().absolute())
-SCRATCH_DIR = str(Path("{{location_scratch_dir}}").expanduser().absolute())
-
 available_port_data = {}
 condition: Condition = Condition()
 connections: MutableMapping[str, MutableMapping[str, socket]] = {}
 ports: MutableMapping[str, Any] = {}
 stopping: bool = False
-
 
 logger = logging.getLogger("swirlc")
 defaultStreamHandler = logging.StreamHandler()
@@ -227,22 +223,19 @@ wait_function = """def _wait(threads: MutableSequence[Thread]):
         t.join()
 """
 
-
-preamble = Template(
-    "\n".join(
-        [
-            python_header,
-            imports,
-            global_vars,
-            accept_function,
-            exec_function,
-            init_dataset_function,
-            send_function,
-            recv_function,
-            thread_function,
-            wait_function,
-        ]
-    )
+preamble = "\n".join(
+    [
+        python_header,
+        imports,
+        global_vars,
+        accept_function,
+        exec_function,
+        init_dataset_function,
+        send_function,
+        recv_function,
+        thread_function,
+        wait_function,
+    ]
 )
 
 
@@ -301,12 +294,7 @@ class DefaultTarget(BaseCompiler):
         self.programs[self.current_location.name] = open(
             os.path.join(self.outdir, f"{self.current_location.name}.py"), "w"
         )
-        self.programs[self.current_location.name].write(
-            preamble.render(
-                location_scratch_dir=self.current_location.workdir,
-                location_out_dir=self.current_location.outdir,
-            )
-        )
+        self.programs[self.current_location.name].write(preamble)
         location = self.workflow.locations[self.current_location.name]
         self.programs[self.current_location.name].write(f"""def main():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -336,7 +324,18 @@ class DefaultTarget(BaseCompiler):
         raise NotImplementedError("Choice is not implemented yet")
 
     def end_location(self) -> None:
-        self.programs[self.current_location.name].write("""
+        out_dir = (
+            f'str(Path("{self.current_location.outdir}").expanduser().absolute())'
+            if self.current_location.outdir
+            else "os.getcwd()"
+        )
+        scratch_dir = (
+            f'str(Path("{self.current_location.workdir}").expanduser().absolute())'
+            if self.current_location.workdir
+            else "os.getcwd()"
+        )
+        self.programs[self.current_location.name].write(
+            """
     logger.info("Terminated trace")
     global stopping
     stopping = True""")
@@ -350,8 +349,13 @@ class DefaultTarget(BaseCompiler):
 locations = {{
 {locations}
 }}
-""")
-        self.programs[self.current_location.name].write("""
+
+OUT_DIR = {out_dir}
+SCRATCH_DIR = {scratch_dir}
+"""
+        )
+        self.programs[self.current_location.name].write(
+            """
 if __name__ == '__main__':
     main()
 """)

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -7,6 +7,8 @@ from collections.abc import MutableMapping, MutableSequence
 from pathlib import Path
 from typing import TextIO
 
+from black import WriteBack
+
 from swirlc.core.compiler import BaseCompiler
 from swirlc.core.entity import Data, DistributedWorkflow, Location, Port, Step, Workflow
 from swirlc.log_handler import logger
@@ -334,8 +336,7 @@ class DefaultTarget(BaseCompiler):
             if self.current_location.workdir
             else "os.getcwd()"
         )
-        self.programs[self.current_location.name].write(
-            """
+        self.programs[self.current_location.name].write("""
     logger.info("Terminated trace")
     global stopping
     stopping = True""")
@@ -352,10 +353,8 @@ locations = {{
 
 OUT_DIR = {out_dir}
 SCRATCH_DIR = {scratch_dir}
-"""
-        )
-        self.programs[self.current_location.name].write(
-            """
+""")
+        self.programs[self.current_location.name].write("""
 if __name__ == '__main__':
     main()
 """)

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -7,8 +7,6 @@ from collections.abc import MutableMapping, MutableSequence
 from pathlib import Path
 from typing import TextIO
 
-from black import WriteBack
-
 from swirlc.core.compiler import BaseCompiler
 from swirlc.core.entity import Data, DistributedWorkflow, Location, Port, Step, Workflow
 from swirlc.log_handler import logger
@@ -46,6 +44,8 @@ from typing import Any, MutableMapping, MutableSequence
 global_vars = """
 
 BUF_SIZE = 8192
+OUT_DIR = str(Path("{{location_out_dir}}").expanduser().absolute())
+SCRATCH_DIR = str(Path("{{location_scratch_dir}}").expanduser().absolute())
 
 available_port_data = {}
 condition: Condition = Condition()
@@ -82,12 +82,12 @@ accept_function = """def _accept(sock: socket):
     sock.close()
 """
 
-exec_function = """def _exec(step_name: str, step_display_name: str, input_port_names: MutableSequence[str], output_port_name: str, data_type: str, glob_regex: str | None, cmd: str, args: MutableSequence[str], args_from: MutableSequence[tuple[str, str]], workdir: str):
+exec_function = """def _exec(step_name: str, step_display_name: str, input_port_names: MutableSequence[str], output_port_name: str, data_type: str, glob_regex: str | None, cmd: str, args: MutableSequence[str], args_from: MutableSequence[tuple[str, str]]):
     # Wait all the data
     for port_name in input_port_names:
         available_port_data[port_name].wait()
     # Prepare working directory
-    workdir = os.path.join(workdir, f"exec_{step_name}_{uuid.uuid4()}")
+    workdir = os.path.join(SCRATCH_DIR, f"exec_{step_name}_{uuid.uuid4()}")
     os.mkdir(workdir)
     for port_name in input_port_names:
         os.symlink(os.path.abspath(ports[port_name]), os.path.join(workdir, os.path.basename(ports[port_name])))
@@ -176,7 +176,7 @@ send_function = """def _send(port: str, data_type: str, src: str, dst: str):
     sock.close()
 """
 
-recv_function = """def _recv(port: str, workdir: str, data_type: str, src: str) -> Any:
+recv_function = """def _recv(port: str, data_type: str, src: str) -> Any:
     buf = BytesIO()
     with condition:
         while connections.setdefault(src, {}).get(port) is None:
@@ -197,7 +197,7 @@ recv_function = """def _recv(port: str, workdir: str, data_type: str, src: str) 
     elif data_type == "file":
         filename = connections[src][port].recv(1024).decode()
         connections[src][port].send("ack".encode("utf-8"))
-        filepath = os.path.join(workdir, f"rcv_{port}_{uuid.uuid4()}", filename)
+        filepath = os.path.join(SCRATCH_DIR, f"rcv_{port}_{uuid.uuid4()}", filename)
         os.mkdir(os.path.dirname(filepath))
         fd = open(filepath, "wb")
         while True:
@@ -227,19 +227,22 @@ wait_function = """def _wait(threads: MutableSequence[Thread]):
         t.join()
 """
 
-preamble = "\n".join(
-    [
-        python_header,
-        imports,
-        global_vars,
-        accept_function,
-        exec_function,
-        init_dataset_function,
-        send_function,
-        recv_function,
-        thread_function,
-        wait_function,
-    ]
+
+preamble = Template(
+    "\n".join(
+        [
+            python_header,
+            imports,
+            global_vars,
+            accept_function,
+            exec_function,
+            init_dataset_function,
+            send_function,
+            recv_function,
+            thread_function,
+            wait_function,
+        ]
+    )
 )
 
 
@@ -298,7 +301,12 @@ class DefaultTarget(BaseCompiler):
         self.programs[self.current_location.name] = open(
             os.path.join(self.outdir, f"{self.current_location.name}.py"), "w"
         )
-        self.programs[self.current_location.name].write(preamble)
+        self.programs[self.current_location.name].write(
+            preamble.render(
+                location_scratch_dir=self.current_location.workdir,
+                location_out_dir=self.current_location.outdir,
+            )
+        )
         location = self.workflow.locations[self.current_location.name]
         self.programs[self.current_location.name].write(f"""def main():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -460,7 +468,7 @@ echo "Workflow execution terminated"
     {self._get_indentation()}input_port_names = {[port_name for port_name, _ in flow[0]]}
     {self._get_indentation()}for port_name in input_port_names:
     {self._get_indentation()}    available_port_data.setdefault(port_name, Event())
-    {self._get_indentation()}_exec("{step.name}", "{step.display_name}", input_port_names, "{output_port_name}", "{step.processors[output_port_name].type if output_port_name else ""}", "{step.processors[output_port_name].glob if output_port_name else ""}", "{step.command}", {arguments}, {arguments_from_port}, str(Path("{self.current_location.workdir}").expanduser().absolute()))"""
+    {self._get_indentation()}_exec("{step.name}", "{step.display_name}", input_port_names, "{output_port_name}", "{step.processors[output_port_name].type if output_port_name else ""}", "{step.processors[output_port_name].glob if output_port_name else ""}", "{step.command}", {arguments}, {arguments_from_port})"""
         )
 
     def par(self) -> None:
@@ -483,7 +491,7 @@ echo "Workflow execution terminated"
     def recv(self, port: str, data_type: str, src: str, dst: str):
         self.programs[self.current_location.name].write(
             f"""
-    {self._get_indentation()}{self._get_thread(self.current_location.name)} = _thread(_recv, "{port}", str(Path("{self.current_location.workdir}").expanduser().absolute()), "{data_type}", "{src}")"""
+    {self._get_indentation()}{self._get_thread(self.current_location.name)} = _thread(_recv, "{port}", "{data_type}", "{src}")"""
         )
 
     def send(self, data: str, port: str, data_type: str, src: str, dst: str):

--- a/swirlc/core/entity.py
+++ b/swirlc/core/entity.py
@@ -65,7 +65,7 @@ class Location:
                 ]
             )
         elif self.connection_type is None:
-            return f"cd {self.workdir} && " if self.workdir else "" + cmd
+            return (f"cd {self.workdir} && " if self.workdir else "") + cmd
         else:
             raise NotImplementedError(
                 f"Connection type: {self.connection_type} not supported"

--- a/swirlc/parser.py
+++ b/swirlc/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 import swirlc.compiler
 import swirlc.translator
@@ -34,7 +35,7 @@ compile_parser.add_argument(
     "-o",
     type=str,
     help="Output directory path. It will be create a set of files: `run.sh` and `l*.py`",
-    default="",
+    default=os.getcwd(),
 )
 
 # Swirl translator
@@ -61,7 +62,7 @@ translate_parser.add_argument(
     "-o",
     type=str,
     help="Output directory path. It will be create two files: `workflow.swirl` and `metadata.yml`",
-    default="",
+    default=os.getcwd(),
 )
 
 # Swirl version

--- a/swirlc/translator/dax_translator.py
+++ b/swirlc/translator/dax_translator.py
@@ -123,6 +123,7 @@ class DAXTranslator(AbstractTranslator):
                         swirl_step_args[swirl_collect_step_name] = [
                             "-r",
                             swirl_data_name,
+                            "OUT_DIR",
                         ]
                         # Add output port of previous step as input of the collector step
                         swirl_input_steps.setdefault(
@@ -261,8 +262,5 @@ class DAXTranslator(AbstractTranslator):
                     ):
                         workflow.map(
                             workflow.steps[c], workflow.locations[location_name]
-                        )
-                        workflow.steps[c].arguments.append(
-                            workflow.locations[location_name].outdir
                         )
         return workflow

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,12 +1,39 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import pathlib
+import re
+import shutil
+import signal
+import socket
+import subprocess
 import tempfile
+from collections.abc import MutableSequence
+
+from ruamel.yaml import YAML
 
 from swirlc.main import main
 
-EXAMPLES_PATH = pathlib.Path(__file__).parent.parent / "examples"
+_EXAMPLES_PATH = pathlib.Path(__file__).parent.parent / "examples"
+
+
+@contextlib.contextmanager
+def sockets_contextmanager():
+    sockets: list[socket.socket] = []
+    try:
+        yield sockets
+    finally:
+        for sock in sockets:
+            sock.close()
+
+
+def _reserve_port(reserved_sockets: MutableSequence[socket.socket]) -> int:
+    """Helper to bind a socket, keep it open, and return the port."""
+    tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tcp.bind(("", 0))
+    reserved_sockets.append(tcp)
+    return tcp.getsockname()[1]
 
 
 def _compile(trace_file: str, config_file: str, outdir: str | None = None) -> None:
@@ -16,15 +43,112 @@ def _compile(trace_file: str, config_file: str, outdir: str | None = None) -> No
         assert main(["compile", trace_file, config_file, "--outdir", outdir]) == 0
 
 
+def _compile_and_run(
+    example_name: str,
+    trace_filename: str,
+    expected_generated_files: MutableSequence[str],
+    expected_stdout: str | None = None,
+    expected_stderr_patterns: MutableSequence[str] | None = None,
+    extra_files_to_copy: MutableSequence[str] | None = None,
+    timeout: int = 15,
+) -> None:
+    example_dir = _EXAMPLES_PATH / example_name
+
+    with tempfile.TemporaryDirectory() as workdir:
+        config_file = os.path.join(workdir, "config.yml")
+
+        with sockets_contextmanager() as reserved_sockets:
+            _update_config_metadata(
+                src_path=str(example_dir / "config.yml"),
+                dst_path=config_file,
+                reserved_sockets=reserved_sockets,
+            )
+
+            _compile(
+                trace_file=str(example_dir / trace_filename),
+                config_file=config_file,
+                outdir=workdir,
+            )
+            for file in expected_generated_files:
+                assert os.path.exists(
+                    os.path.join(workdir, file)
+                ), f"File '{file}' was not generated during compilation."
+            if extra_files_to_copy:
+                for file in extra_files_to_copy:
+                    shutil.copyfile(
+                        str(example_dir / file),
+                        os.path.join(workdir, file),
+                    )
+        process = subprocess.Popen(
+            ["./run.sh"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=workdir,
+        )
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.send_signal(signal.SIGINT)
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"The compiled program timed out (SIGINT sent). stdout: {stdout}\nstderr: {stderr}"
+            )
+
+        assert process.returncode == 0, f"Program crashed! Stderr: {stderr}"
+        if expected_stdout is not None:
+            assert (
+                stdout.strip() == expected_stdout
+            ), f"Missing expected output. \n\nFull stdout was:\n{stdout}"
+        if expected_stderr_patterns:
+            for pattern in expected_stderr_patterns:
+                formatted_pattern = pattern.replace("{workdir}", workdir)
+                match = re.search(formatted_pattern, stderr)
+                assert (
+                    match
+                ), f"Missing expected log: '{formatted_pattern}'\n\nFull stderr was:\n{stderr}"
+
+
+def _update_config_metadata(
+    src_path: str, dst_path: str, reserved_sockets: MutableSequence[socket.socket]
+) -> None:
+    """
+    Copy the metadata from the source to a new working directory.
+    In the copied metadata, an available port is assigned to each location.
+
+    Important: The caller is responsible for iterating through `reserved_sockets`
+    and closing them to free the ports once the setup is complete.
+    """
+    with open(src_path) as f:
+        yaml = YAML(typ="safe")
+        config_data = yaml.load(f)
+
+    for _, settings in config_data["locations"].items():
+        settings["port"] = _reserve_port(reserved_sockets)
+
+    assert not os.path.exists(dst_path), f"Destination path {dst_path} already exists"
+
+    with open(dst_path, "w") as f:
+        yaml.dump(config_data, f)
+
+
 def test_example1() -> None:
     _compile(
-        str(EXAMPLES_PATH / "example1" / "example1.swirl"),
-        str(EXAMPLES_PATH / "example1" / "config.yml"),
+        str(_EXAMPLES_PATH / "example1" / "example1.swirl"),
+        str(_EXAMPLES_PATH / "example1" / "config.yml"),
     )
 
 
 def test_example2() -> None:
-    _compile(
-        str(EXAMPLES_PATH / "example2" / "example2.swirl"),
-        str(EXAMPLES_PATH / "example2" / "config.yml"),
+    _compile_and_run(
+        example_name="example2",
+        trace_filename="example2.swirl",
+        expected_generated_files=["run.sh", "ld.py", "l1.py", "l2.py"],
+        extra_files_to_copy=["world.txt"],
+        expected_stdout="Workflow execution terminated",
+        expected_stderr_patterns=[
+            r"Step FirstStep-s1 result file: '{workdir}/.*/hello\.txt'",
+            r"Step SecondStep-s2 has not an output port\. Result: 'Hello'",
+            r"Step ThirdStep-s3 has not an output port\. Result: 'Hello'",
+        ],
     )


### PR DESCRIPTION
This commit addresses several issues related to working directories:

* **Refactors directory variables:** Changes scratch and output directories from `_exec` and `_recv` arguments to global variables.
* **Fixes missing workdir errors:** Resolves a runtime execution error in the trace caused by locations with undefined working directories.
* **Sets default CLI directories:** Uses the current working directory as the default value for CLI `compile` and `translate` commands.
* **Improves testing:** Verifies functionality by executing the example scripts after compilation.