### PR TITLE
Fix wrongly named folder in ANTLR4 generator script

### DIFF
--- a/scripts/generate-antlr4-parsers.sh
+++ b/scripts/generate-antlr4-parsers.sh
@@ -24,7 +24,7 @@ docker run                                                \
   -o /swirl/parsers/python                                \
   -visitor                                                \
   /swirl/grammar/SWIRL.g4
-mv ${TMP_DIRECTORY}/python/*.py "${SOURCE_DIRECTORY}/swirl/antlr/"
+mv ${TMP_DIRECTORY}/python/*.py "${SOURCE_DIRECTORY}/swirlc/antlr/"
 
 # Remove tmp destination directory
 rm -rf "${TMP_DIRECTORY}"


### PR DESCRIPTION
This commit updates the source folder name within the script `generate-antlr4-parsers.sh` to guarantee its functionality after the project rename.