### PR TITLE
Updated Python support 

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         on: [ "ubuntu-22.04"]
-        python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     runs-on: ${{ matrix.on }}
     env:
       TOXENV: ${{ format('py{0}-unit', matrix.python) }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format-check:
 	black --diff --check swirlc tests
 
 pyupgrade:
-	pyupgrade --py3-only --py38-plus $(shell git ls-files | grep .py | grep -v swirlc/antlr)
+	pyupgrade --py3-only --py39-plus $(shell git ls-files | grep .py | grep -v swirlc/antlr)
 
 test:
 	python -m pytest -rs ${PYTEST_EXTRA}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `swirlc` package is available on [PyPi](https://pypi.org/project/swirlc/), s
 pip install swirlc
 ```
 
-Please note that the SWIRL compiler requires `python >= 3.8`. Then you can use it through the `swirlc` CLI.
+Please note that the SWIRL compiler requires `python >= 3.9`. Then you can use it through the `swirlc` CLI.
 
 ### Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Scientific Workflow Intermediate Representation Language"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "LGPL-3.0-or-later"}
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -21,10 +21,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing"
 ]

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -4,7 +4,8 @@ import os
 import stat
 import sys
 from pathlib import Path
-from typing import MutableMapping, MutableSequence, TextIO
+from typing import TextIO
+from collections.abc import MutableMapping, MutableSequence
 
 from black import WriteBack
 
@@ -367,7 +368,7 @@ if __name__ == '__main__':
                 Path(f"{self.current_location.name}.py"),
                 fast=False,
                 mode=black.mode.Mode(
-                    target_versions={black.mode.TargetVersion.PY38}, line_length=88
+                    target_versions={black.mode.TargetVersion.PY39}, line_length=88
                 ),
                 write_back=WriteBack.YES,
             )

--- a/swirlc/config/validator.py
+++ b/swirlc/config/validator.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from typing import Any, MutableMapping
+    from typing import Any
+    from collections.abc import MutableMapping
 
 
 def handle_errors(errors):

--- a/swirlc/core/compiler.py
+++ b/swirlc/core/compiler.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, MutableMapping, MutableSequence
+from typing import Any
+from collections.abc import MutableMapping, MutableSequence
 
 from swirlc.antlr.SWIRLParser import SWIRLParser
 from swirlc.antlr.SWIRLVisitor import SWIRLVisitor

--- a/swirlc/core/entity.py
+++ b/swirlc/core/entity.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import PurePath
-from typing import Any, MutableMapping, MutableSequence
+from typing import Any
+from collections.abc import MutableMapping, MutableSequence
 
 from swirlc.core.utils import flatten_list
 

--- a/swirlc/main.py
+++ b/swirlc/main.py
@@ -45,11 +45,14 @@ def main(args):
                         raise Exception(
                             f"Output directory `{args.outdir}` does not exist"
                         )
-                    with open(
-                        os.path.join(args.outdir, "workflow.swirl"), "w"
-                    ) as workflow_output, open(
-                        os.path.join(args.outdir, "metadata.yml"), "w"
-                    ) as metadata_output:
+                    with (
+                        open(
+                            os.path.join(args.outdir, "workflow.swirl"), "w"
+                        ) as workflow_output,
+                        open(
+                            os.path.join(args.outdir, "metadata.yml"), "w"
+                        ) as metadata_output,
+                    ):
                         translator.translate(workflow_output, metadata_output)
                 else:
                     translator.translate(sys.stdout, sys.stdout)

--- a/swirlc/translator/dax_translator.py
+++ b/swirlc/translator/dax_translator.py
@@ -4,7 +4,7 @@ import glob
 import logging
 import os
 from pathlib import Path
-from typing import MutableMapping, MutableSequence
+from collections.abc import MutableMapping, MutableSequence
 
 from ruamel.yaml import YAML
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -89,9 +89,10 @@ def test_translate():
             return workflow
 
     translator = ExampleTranslator()
-    with NamedTemporaryFile("w+") as workflow_fd, NamedTemporaryFile(
-        "w+"
-    ) as metadata_fd:
+    with (
+        NamedTemporaryFile("w+") as workflow_fd,
+        NamedTemporaryFile("w+") as metadata_fd,
+    ):
         translator.translate(workflow_fd, metadata_fd)
         assert get_sha1(workflow_fd.name) == "da39a3ee5e6b4b0d3255bfef95601890afd80709"
         assert get_sha1(metadata_fd.name) == "d5ff5195ce296fcd334b6cbb4366b0b2b3e34c88"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   bandit
   lint
-  py3.{8,9,10,11,12}-unit
+  py3.{9,10,11,12,13}-unit
 skip_missing_interpreters = True
 
 [pytest]
@@ -11,19 +11,19 @@ testpaths = tests
 [testenv]
 allowlist_externals = make
 commands_pre =
-  py3.{8,9,10,11,12}-unit: python -m pip install -U pip setuptools wheel
+  py3.{9,10,11,12,13}-unit: python -m pip install -U pip setuptools wheel
 commands =
-  py3.{8,9,10,11,12}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
+  py3.{9,10,11,12,13}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
 deps =
-  py3.{8,9,10,11,12}-unit: -rrequirements.txt
-  py3.{8,9,10,11,12}-unit: -rtest-requirements.txt
+  py3.{9,10,11,12,13}-unit: -rrequirements.txt
+  py3.{9,10,11,12,13}-unit: -rtest-requirements.txt
 description =
-  py3.{8,9,10,11,12}-unit: Run the unit tests
+  py3.{9,10,11,12,13}-unit: Run the unit tests
 passenv =
   CI
   GITHUB_*
 setenv =
-  py3.{8,9,10,11,12}-unit: LC_ALL = C.UTF-8
+  py3.{9,10,11,12,13}-unit: LC_ALL = C.UTF-8
 
 [testenv:bandit]
 commands = bandit -r swirlc


### PR DESCRIPTION
This commit includes Python 3.13 in the CI pipeline and drops Python 3.8.

Python 3.8 is also dropped for the trace format style (`black` package).