### PR TITLE
Fixed multi step outputs (DAX translator)

### DIFF
--- a/swirlc/translator/dax_translator.py
+++ b/swirlc/translator/dax_translator.py
@@ -112,8 +112,8 @@ class DAXTranslator(AbstractTranslator):
                         swirl_data_name
                     )
                     if data["stageOut"]:
-                        # Generate a unique id for the collector step based on the DAX id of the previous step
-                        collect_id = "COLLECT-" + replica["id"]
+                        # Generate a unique id for the collector step
+                        collect_id = f"COLLECT-{replica['id']}-{swirl_data_name}"
                         dax_step_name_id.setdefault(
                             f"{replica['name']}-{swirl_data_name}-collector", []
                         ).append(collect_id)


### PR DESCRIPTION
This commit fixes a DAX translation error.
A step can have multiple outputs, some of which can be workflow outputs. Before this commit, if a step had multiple workflow outputs, an exception was raised at translation time.