### PR TITLE
Added the possibility of having a single input file (DAX translator).

### DIFF
--- a/swirlc/core/utils.py
+++ b/swirlc/core/utils.py
@@ -24,9 +24,9 @@ def get_flow(
     )
 
 
-def get_pair(ctx: SWIRLParser.DataPairContext) -> tuple[str, str]:
-    return (get_name(ctx.port()), get_name(ctx.data()))
-
-
 def get_name(el: antlr4.ParserRuleContext) -> str:
     return el.ID().getText()
+
+
+def get_pair(ctx: SWIRLParser.DataPairContext) -> tuple[str, str]:
+    return (get_name(ctx.port()), get_name(ctx.data()))


### PR DESCRIPTION
This commit allows the DAX to be defined as a single YAML file.
Before this commit, the translator input was a directory with four files. Now, it is possible to have a directory, as before, or a single YAML file that contains the `workflow`, `sites`, `transformations`, `and replicas` data.