### PR TITLE
Add `test_compiler`

### DIFF
--- a/examples/example1/config.yml
+++ b/examples/example1/config.yml
@@ -1,18 +1,29 @@
 version: v1.0
 steps:
   s1:
-    command: echo
+    displayName: s1
+    command: sh
     arguments:
-      - valueFrom: d0
+      - valueFrom: p1
       - value: Hello
+      - value: Ciao
+    outputs:
+      p2:
+        dataName: d1
+        glob: "Hello.txt"
+      p3:
+        dataName: d2
+        glob: "Ciao.txt"
   s2:
+    displayName: s2
     command: echo
     arguments:
-      - valueFrom: d1
+      - valueFrom: p2
   s3:
+    displayName: s3
     command: echo
     arguments:
-      - valueFrom: d2
+      - valueFrom: p3
 
 
 locations:
@@ -31,6 +42,10 @@ locations:
 
 
 dependencies:
-  d0: first_data.txt
-  d1: my_data.txt
-  d2: another_data.txt
+  d:
+    type: file
+    value: custom_cmd.sh
+  d1:
+    type: file
+  d2:
+    type: file

--- a/examples/example1/custom_cmd.sh
+++ b/examples/example1/custom_cmd.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 ENTRY1 ENTRY2"
+    exit 1
+fi
+echo $RANDOM > $1.txt
+echo $RANDOM > $2.txt

--- a/examples/example1/example1.swirl
+++ b/examples/example1/example1.swirl
@@ -1,4 +1,4 @@
-<ld, {d}, exec(s1,{(p1, d)}->{(p2, d1),(p3, d2)},{ld}).(send(d1->p2,ld,l1) | send(d2->p3,ld,l2) | send(d2->p3,ld,l3))> |
+<ld, {(p1, d)}, exec(s1,{(p1, d)}->{(p2, d1),(p3, d2)},{ld}).(send(d1->p2,ld,l1) | send(d2->p3,ld,l2) | send(d2->p3,ld,l3))> |
 <l1, {}, recv(p2,ld,l1).exec(s2,{(p2, d1)}->{},{l1})> |
 <l2, {}, recv(p3,ld,l2).exec(s3,{(p3, d2)}->{},{l2,l3})> |
 <l3, {}, recv(p3,ld,l3).exec(s3,{(p3, d2)}->{},{l2,l3})>

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -265,8 +265,8 @@ class ThreadStack:
 
 
 class DefaultTarget(BaseCompiler):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, outdir: str) -> None:
+        super().__init__(outdir)
         self.current_location: Location | None = None
         self.functions = []
         self.function_counter = 0
@@ -298,7 +298,7 @@ class DefaultTarget(BaseCompiler):
     def begin_location(self, location: Location) -> None:
         self.current_location = location
         self.programs[self.current_location.name] = open(
-            f"{self.current_location.name}.py", "w"
+            os.path.join(self.outdir, f"{self.current_location.name}.py"), "w"
         )
         self.programs[self.current_location.name].write(preamble)
         location = self.workflow.locations[self.current_location.name]
@@ -365,7 +365,7 @@ if __name__ == '__main__':
             import black
 
             black.format_file_in_place(
-                Path(f"{self.current_location.name}.py"),
+                Path(self.outdir, f"{self.current_location.name}.py"),
                 fast=False,
                 mode=black.mode.Mode(
                     target_versions={black.mode.TargetVersion.PY39}, line_length=88
@@ -437,7 +437,7 @@ if __name__ == '__main__':
             )
             + " &"
         )
-        with open(script_name, "w") as f:
+        with open(os.path.join(self.outdir, script_name), "w") as f:
             f.write(
                 f"""{bash_header}
 
@@ -453,7 +453,9 @@ echo "Workflow execution terminated"
             )
         usr_permissions = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
         grp_permissions = stat.S_IRGRP | stat.S_IXGRP
-        os.chmod(script_name, usr_permissions | grp_permissions)
+        os.chmod(
+            os.path.join(self.outdir, script_name), usr_permissions | grp_permissions
+        )
 
     def exec(
         self,

--- a/swirlc/core/compiler.py
+++ b/swirlc/core/compiler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from abc import ABC
 from typing import Any
 from collections.abc import MutableMapping, MutableSequence
@@ -19,6 +20,11 @@ from swirlc.core.entity import (
 
 
 class BaseCompiler:
+    def __init__(self, outdir: str) -> None:
+        self.outdir: str = outdir
+        if not os.path.exists(self.outdir):
+            raise Exception(f"Output directory `{self.outdir}` does not exist")
+
     def begin_choice(self) -> None:
         """Before processing the left operand of a choice operator."""
         pass

--- a/swirlc/main.py
+++ b/swirlc/main.py
@@ -27,7 +27,7 @@ def main(args):
             with open(args.workflow) as f:
                 code = f.read()
             if args.target in swirlc.compiler.targets:
-                target = swirlc.compiler.targets[args.target]()
+                target = swirlc.compiler.targets[args.target](args.outdir)
                 lexer = SWIRLLexer(antlr4.InputStream(code))
                 tokens = antlr4.CommonTokenStream(lexer)
                 tree = SWIRLParser(tokens).workflow()

--- a/swirlc/parser.py
+++ b/swirlc/parser.py
@@ -29,6 +29,13 @@ compile_parser.add_argument(
     choices=swirlc.compiler.targets,
     help="The compilation target",
 )
+compile_parser.add_argument(
+    "--outdir",
+    "-o",
+    type=str,
+    help="Output directory path. It will be create a set of files: `run.sh` and `l*.py`",
+    default="",
+)
 
 # Swirl translator
 translate_parser = subparsers.add_parser(

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,23 +1,28 @@
+from __future__ import annotations
+import contextlib
 import pathlib
-
+import tempfile
 
 from swirlc.main import main
 
 EXAMPLES_PATH = pathlib.Path(__file__).parent.parent / "examples"
 
 
-def _compile(trace_file: str, config_file: str) -> None:
-    assert main(["compile", trace_file, config_file]) == 0
+def _compile(trace_file: str, config_file: str, outdir: str | None = None) -> None:
+    with contextlib.ExitStack() as stack:
+        if outdir is None:
+            outdir = stack.enter_context(tempfile.TemporaryDirectory())
+        assert main(["compile", trace_file, config_file, "--outdir", outdir]) == 0
 
 
-def test_example1():
+def test_example1() -> None:
     _compile(
         str(EXAMPLES_PATH / "example1" / "example1.swirl"),
         str(EXAMPLES_PATH / "example1" / "config.yml"),
     )
 
 
-def test_example2():
+def test_example2() -> None:
     _compile(
         str(EXAMPLES_PATH / "example2" / "example2.swirl"),
         str(EXAMPLES_PATH / "example2" / "config.yml"),

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,24 @@
+import pathlib
+
+
+from swirlc.main import main
+
+EXAMPLES_PATH = pathlib.Path(__file__).parent.parent / "examples"
+
+
+def _compile(trace_file: str, config_file: str) -> None:
+    assert main(["compile", trace_file, config_file]) == 0
+
+
+def test_example1():
+    _compile(
+        str(EXAMPLES_PATH / "example1" / "example1.swirl"),
+        str(EXAMPLES_PATH / "example1" / "config.yml"),
+    )
+
+
+def test_example2():
+    _compile(
+        str(EXAMPLES_PATH / "example2" / "example2.swirl"),
+        str(EXAMPLES_PATH / "example2" / "config.yml"),
+    )


### PR DESCRIPTION
This commit adds new compiler test, using the available examples

Moreover, this commit adds the `outdir` parameter to the `compiler` CLI.
BREAKING CHANGE: This breaks existing subclasses of the `BaseCompiler` class.