### PR TITLE
Updated Python support to `>=3.10`

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         on: [ "ubuntu-22.04"]
-        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python: [ "3.10", "3.11", "3.12", "3.13", "3.14"  ]
     runs-on: ${{ matrix.on }}
     env:
       TOXENV: ${{ format('py{0}-unit', matrix.python) }}

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ format-check:
 	black --diff --check swirlc tests
 
 pyupgrade:
-	pyupgrade --py3-only --py39-plus $(shell git ls-files | grep .py | grep -v swirlc/antlr)
+	pyupgrade --py3-only --py310-plus $(shell git ls-files | grep .py | grep -v swirlc/antlr)
 
 test:
 	python -m pytest -rs ${PYTEST_EXTRA}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `swirlc` package is available on [PyPi](https://pypi.org/project/swirlc/), s
 pip install swirlc
 ```
 
-Please note that the SWIRL compiler requires `python >= 3.9`. Then you can use it through the `swirlc` CLI.
+Please note that the SWIRL compiler requires `python >= 3.10`. Then you can use it through the `swirlc` CLI.
 
 ### Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Scientific Workflow Intermediate Representation Language"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "LGPL-3.0-or-later"}
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -21,11 +21,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing"
 ]

--- a/swirlc/compiler/default.py
+++ b/swirlc/compiler/default.py
@@ -368,7 +368,7 @@ if __name__ == '__main__':
                 Path(f"{self.current_location.name}.py"),
                 fast=False,
                 mode=black.mode.Mode(
-                    target_versions={black.mode.TargetVersion.PY39}, line_length=88
+                    target_versions={black.mode.TargetVersion.PY310}, line_length=88
                 ),
                 write_back=WriteBack.YES,
             )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
   bandit
   lint
-  py3.{9,10,11,12,13}-unit
+  py3.{10,11,12,13,14}-unit
 skip_missing_interpreters = True
 
 [pytest]
@@ -11,19 +11,19 @@ testpaths = tests
 [testenv]
 allowlist_externals = make
 commands_pre =
-  py3.{9,10,11,12,13}-unit: python -m pip install -U pip setuptools wheel
+  py3.{10,11,12,13,14}-unit: python -m pip install -U pip setuptools wheel
 commands =
-  py3.{9,10,11,12,13}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
+  py3.{10,11,12,13,14}-unit: make coverage-report coverage.xml PYTEST_EXTRA={posargs}
 deps =
-  py3.{9,10,11,12,13}-unit: -rrequirements.txt
-  py3.{9,10,11,12,13}-unit: -rtest-requirements.txt
+  py3.{10,11,12,13,14}-unit: -rrequirements.txt
+  py3.{10,11,12,13,14}-unit: -rtest-requirements.txt
 description =
-  py3.{9,10,11,12,13}-unit: Run the unit tests
+  py3.{10,11,12,13,14}-unit: Run the unit tests
 passenv =
   CI
   GITHUB_*
 setenv =
-  py3.{9,10,11,12,13}-unit: LC_ALL = C.UTF-8
+  py3.{10,11,12,13,14}-unit: LC_ALL = C.UTF-8
 
 [testenv:bandit]
 commands = bandit -r swirlc


### PR DESCRIPTION
This commit includes Python 3.14 in the CI pipeline and drops Python 3.9.

Python 3.9 is also dropped from the trace format style (`black` package).